### PR TITLE
Create Keyable module to generate Enigma inputs

### DIFF
--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -3,7 +3,7 @@ require './lib/keyable'
 class Enigma
   include Keyable
 
-  def encrypt(message, key, date)
+  def encrypt(message, key = Keyable.random_key, date = Keyable.date_today)
     letter_indexes = convert_to_indexes(message)
     shifts = get_shifts(key, date)
     encrypted_indexes = encrypt_by_index(letter_indexes, shifts)
@@ -11,7 +11,7 @@ class Enigma
     format_encryption_hash(encryption, key, date)
   end
 
-  def decrypt(message, key, date)
+  def decrypt(message, key = Keyable.random_key, date = Keyable.date_today)
     letter_indexes = convert_to_indexes(message)
     shifts = get_shifts(key, date)
     decrypted_indexes = decrypt_by_index(letter_indexes, shifts)

--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -62,9 +62,6 @@ class Enigma
     end
   end
 
-  # method for generating random 5-digit, zero-padded #s
-  # method for generating random date and converting to string
-
   def get_shifts(key, date)
     keys = shift_keys(key)
     offsets = shift_offsets(date)

--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -91,7 +91,7 @@ class Enigma
   end
 
   def format_encryption_hash(encryption, key, date)
-    encrypted_message = Hash.new
+    encrypted_message = {}
     encrypted_message[:encryption] = encryption
     encrypted_message[:key] = key
     encrypted_message[:date] = date
@@ -99,7 +99,7 @@ class Enigma
   end
 
   def format_decryption_hash(decryption, key, date)
-    decrypted_message = Hash.new
+    decrypted_message = {}
     decrypted_message[:decryption] = decryption
     decrypted_message[:key] = key
     decrypted_message[:date] = date

--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -11,7 +11,7 @@ class Enigma
     format_encryption_hash(encryption, key, date)
   end
 
-  def decrypt(message, key = Keyable.random_key, date = Keyable.date_today)
+  def decrypt(message, key, date = Keyable.date_today)
     letter_indexes = convert_to_indexes(message)
     shifts = get_shifts(key, date)
     decrypted_indexes = decrypt_by_index(letter_indexes, shifts)

--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -1,16 +1,22 @@
+require './lib/keyable'
+
 class Enigma
+  include Keyable
+
   def encrypt(message, key, date)
     letter_indexes = convert_to_indexes(message)
     shifts = get_shifts(key, date)
     encrypted_indexes = encrypt_by_index(letter_indexes, shifts)
-    convert_to_string(encrypted_indexes)
+    encryption = convert_to_string(encrypted_indexes)
+    format_encryption_hash(encryption, key, date)
   end
 
   def decrypt(message, key, date)
     letter_indexes = convert_to_indexes(message)
     shifts = get_shifts(key, date)
     decrypted_indexes = decrypt_by_index(letter_indexes, shifts)
-    convert_to_string(decrypted_indexes)
+    decryption = convert_to_string(decrypted_indexes)
+    format_decryption_hash(decryption, key, date)
   end
 
   def encrypt_by_index(letter_indexes, shifts)
@@ -82,5 +88,21 @@ class Enigma
 
   def letters
     ('a'..'z').to_a << ' '
+  end
+
+  def format_encryption_hash(encryption, key, date)
+    encrypted_message = Hash.new
+    encrypted_message[:encryption] = encryption
+    encrypted_message[:key] = key
+    encrypted_message[:date] = date
+    encrypted_message
+  end
+
+  def format_decryption_hash(decryption, key, date)
+    decrypted_message = Hash.new
+    decrypted_message[:decryption] = decryption
+    decrypted_message[:key] = key
+    decrypted_message[:date] = date
+    decrypted_message
   end
 end

--- a/lib/keyable.rb
+++ b/lib/keyable.rb
@@ -1,12 +1,11 @@
 module Keyable
-
   def self.random_key
     value = (0..100_000).to_a.sample
-    value.to_s.rjust(5, "0")
+    value.to_s.rjust(5, '0')
   end
 
   def self.date_today
     date = Date.today
-    date.strftime("%m%d%y")
+    date.strftime('%m%d%y')
   end
 end

--- a/lib/keyable.rb
+++ b/lib/keyable.rb
@@ -4,4 +4,9 @@ module Keyable
     value = (0..100_000).to_a.sample
     value.to_s.rjust(5, "0")
   end
+
+  def self.date_today
+    date = Date.today
+    date.strftime("%m%d%y")
+  end
 end

--- a/lib/keyable.rb
+++ b/lib/keyable.rb
@@ -1,0 +1,7 @@
+module Keyable
+
+  def self.random_key
+    value = (0..100_000).to_a.sample
+    value.to_s.rjust(5, "0")
+  end
+end

--- a/spec/enigma_spec.rb
+++ b/spec/enigma_spec.rb
@@ -11,15 +11,30 @@ describe Enigma do
   end
 
   describe '#encrypt' do
-    it 'returns an encrypted version of input string' do
+    it 'returns an encrypted version of input string with key and date given' do
       enigma = Enigma.new
 
-      expect(enigma.encrypt('hello world', '02715', '040895')).to eq 'keder ohulw'
+      expected = {
+        encryption: "keder ohulw",
+        key: "02715",
+        date: "040895"
+      }
+      expect(enigma.encrypt('hello world', '02715', '040895')).to eq expected
     end
+    # need to test with only date given
+    # test with only key given
+    # test with uppercase letters
+    # test with unexpected characters
+
+    # it 'returns an encrypted version of input string with only date given' do
+    #   enigma = Enigma.new
+    #
+    #   expect(enigma.encrypt('hello world', '02715', '040895')).to eq 'keder ohulw'
+    # end
   end
 
   describe '#decrypt' do
-    it 'returns a decrypted version of input string' do
+    it 'returns a decrypted version of input string with key and date given' do
       enigma = Enigma.new
 
       expect(enigma.decrypt('keder ohulw', '02715', '040895')).to eq 'hello world'

--- a/spec/enigma_spec.rb
+++ b/spec/enigma_spec.rb
@@ -15,9 +15,9 @@ describe Enigma do
       enigma = Enigma.new
 
       expected = {
-        encryption: "keder ohulw",
-        key: "02715",
-        date: "040895"
+        encryption: 'keder ohulw',
+        key: '02715',
+        date: '040895'
       }
       expect(enigma.encrypt('hello world', '02715', '040895')).to eq expected
     end
@@ -27,7 +27,7 @@ describe Enigma do
       allow(Keyable).to receive(:date_today) { '040895' }
 
       expected = {
-        encryption: "keder ohulw",
+        encryption: 'keder ohulw',
         key: '02715',
         date: '040895'
       }
@@ -40,7 +40,7 @@ describe Enigma do
       allow(Keyable).to receive(:date_today) { '040895' }
 
       expected = {
-        encryption: "keder ohulw",
+        encryption: 'keder ohulw',
         key: '02715',
         date: '040895'
       }
@@ -54,8 +54,8 @@ describe Enigma do
 
       expected = {
         decryption: 'hello world',
-        key: "02715",
-        date: "040895"
+        key: '02715',
+        date: '040895'
       }
       expect(enigma.decrypt('keder ohulw', '02715', '040895')).to eq expected
     end
@@ -170,15 +170,15 @@ describe Enigma do
   describe '#format_encryption_hash' do
     it 'formats the return hash for #encrypt' do
       enigma = Enigma.new
-      encryption = "keder ohulw"
-      key = "02715"
-      date = "040895"
+      encryption = 'keder ohulw'
+      key = '02715'
+      date = '040895'
 
       actual = enigma.format_encryption_hash(encryption, key, date)
       expected = {
-        encryption: "keder ohulw",
-        key: "02715",
-        date: "040895"
+        encryption: 'keder ohulw',
+        key: '02715',
+        date: '040895'
       }
       expect(actual).to eq expected
     end
@@ -187,15 +187,15 @@ describe Enigma do
   describe '#format_decryption_hash' do
     it 'formats the return hash for #decrypt' do
       enigma = Enigma.new
-      decryption = "hello world"
-      key = "02715"
-      date = "040895"
+      decryption = 'hello world'
+      key = '02715'
+      date = '040895'
 
       actual = enigma.format_decryption_hash(decryption, key, date)
       expected = {
-        decryption: "hello world",
-        key: "02715",
-        date: "040895"
+        decryption: 'hello world',
+        key: '02715',
+        date: '040895'
       }
       expect(actual).to eq expected
     end

--- a/spec/enigma_spec.rb
+++ b/spec/enigma_spec.rb
@@ -152,16 +152,33 @@ describe Enigma do
     end
   end
 
-  describe '#format_return_hash' do
-    it 'formats the return hash' do
+  describe '#format_encryption_hash' do
+    it 'formats the return hash for #encrypt' do
       enigma = Enigma.new
       encryption = "keder ohulw"
       key = "02715"
       date = "040895"
 
-      actual = enigma.format_return_hash(encryption, key, date)
+      actual = enigma.format_encryption_hash(encryption, key, date)
       expected = {
         encryption: "keder ohulw",
+        key: "02715",
+        date: "040895"
+      }
+      expect(actual).to eq expected
+    end
+  end
+
+  describe '#format_decryption_hash' do
+    it 'formats the return hash for #decrypt' do
+      enigma = Enigma.new
+      decryption = "hello world"
+      key = "02715"
+      date = "040895"
+
+      actual = enigma.format_decryption_hash(decryption, key, date)
+      expected = {
+        decryption: "hello world",
         key: "02715",
         date: "040895"
       }

--- a/spec/enigma_spec.rb
+++ b/spec/enigma_spec.rb
@@ -11,7 +11,7 @@ describe Enigma do
   end
 
   describe '#encrypt' do
-    it 'returns an encrypted version of input string with key and date given' do
+    it 'returns an encrypted version of input with key and date given' do
       enigma = Enigma.new
 
       expected = {
@@ -22,7 +22,7 @@ describe Enigma do
       expect(enigma.encrypt('hello world', '02715', '040895')).to eq expected
     end
 
-    it 'returns an encrypted version of input string with message and key given' do
+    it 'returns an encrypted version of input with message and key given' do
       enigma = Enigma.new
       allow(Keyable).to receive(:date_today) { '040895' }
 
@@ -34,7 +34,7 @@ describe Enigma do
       expect(enigma.encrypt('hello world', '02715')).to eq expected
     end
 
-    it 'returns an encrypted version of input string with only message given' do
+    it 'returns an encrypted version of input with only message given' do
       enigma = Enigma.new
       allow(Keyable).to receive(:random_key) { '02715' }
       allow(Keyable).to receive(:date_today) { '040895' }
@@ -58,6 +58,18 @@ describe Enigma do
         date: '040895'
       }
       expect(enigma.decrypt('keder ohulw', '02715', '040895')).to eq expected
+    end
+
+    it 'returns an decrypted version of input with message and key given' do
+      enigma = Enigma.new
+      allow(Keyable).to receive(:date_today) { '040895' }
+
+      expected = {
+        encryption: 'keder ohulw',
+        key: '02715',
+        date: '040895'
+      }
+      expect(enigma.encrypt('hello world', '02715')).to eq expected
     end
   end
 

--- a/spec/enigma_spec.rb
+++ b/spec/enigma_spec.rb
@@ -120,12 +120,6 @@ describe Enigma do
     end
   end
 
-  # describe '#generate_key' do
-  #   enigma = Enigma.new
-  #
-  #   expect(enigma.generate_key.length).to eq 5
-  # end
-
   describe '#get_shifts' do
     it 'calculates the four shifts' do
       enigma = Enigma.new
@@ -156,13 +150,9 @@ describe Enigma do
     it 'creates the array of letters' do
       enigma = Enigma.new
 
-      expected = ['a', 'b', 'c', 'd',
-                  'e', 'f', 'g', 'h',
-                  'i', 'j', 'k', 'l',
-                  'm', 'n', 'o', 'p',
-                  'q', 'r', 's', 't',
-                  'u', 'v', 'w', 'x',
-                  'y', 'z', ' ']
+      expected = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i',
+                  'j', 'k', 'l', 'm', 'n', 'o', 'p','q', 'r',
+                  's', 't', 'u', 'v', 'w', 'x', 'y', 'z', ' ']
       expect(enigma.letters).to eq expected
     end
   end

--- a/spec/enigma_spec.rb
+++ b/spec/enigma_spec.rb
@@ -37,7 +37,12 @@ describe Enigma do
     it 'returns a decrypted version of input string with key and date given' do
       enigma = Enigma.new
 
-      expect(enigma.decrypt('keder ohulw', '02715', '040895')).to eq 'hello world'
+      expected = {
+        decryption: 'hello world',
+        key: "02715",
+        date: "040895"
+      }
+      expect(enigma.decrypt('keder ohulw', '02715', '040895')).to eq expected
     end
   end
 
@@ -144,6 +149,23 @@ describe Enigma do
                   'u', 'v', 'w', 'x',
                   'y', 'z', ' ']
       expect(enigma.letters).to eq expected
+    end
+  end
+
+  describe '#format_return_hash' do
+    it 'formats the return hash' do
+      enigma = Enigma.new
+      encryption = "keder ohulw"
+      key = "02715"
+      date = "040895"
+
+      actual = enigma.format_return_hash(encryption, key, date)
+      expected = {
+        encryption: "keder ohulw",
+        key: "02715",
+        date: "040895"
+      }
+      expect(actual).to eq expected
     end
   end
 end

--- a/spec/enigma_spec.rb
+++ b/spec/enigma_spec.rb
@@ -21,16 +21,31 @@ describe Enigma do
       }
       expect(enigma.encrypt('hello world', '02715', '040895')).to eq expected
     end
-    # need to test with only date given
-    # test with only key given
-    # test with uppercase letters
-    # test with unexpected characters
 
-    # it 'returns an encrypted version of input string with only date given' do
-    #   enigma = Enigma.new
-    #
-    #   expect(enigma.encrypt('hello world', '02715', '040895')).to eq 'keder ohulw'
-    # end
+    it 'returns an encrypted version of input string with message and key given' do
+      enigma = Enigma.new
+      allow(Keyable).to receive(:date_today) { '040895' }
+
+      expected = {
+        encryption: "keder ohulw",
+        key: '02715',
+        date: '040895'
+      }
+      expect(enigma.encrypt('hello world', '02715')).to eq expected
+    end
+
+    it 'returns an encrypted version of input string with only message given' do
+      enigma = Enigma.new
+      allow(Keyable).to receive(:random_key) { '02715' }
+      allow(Keyable).to receive(:date_today) { '040895' }
+
+      expected = {
+        encryption: "keder ohulw",
+        key: '02715',
+        date: '040895'
+      }
+      expect(enigma.encrypt('hello world')).to eq expected
+    end
   end
 
   describe '#decrypt' do

--- a/spec/keyable_spec.rb
+++ b/spec/keyable_spec.rb
@@ -1,0 +1,22 @@
+require './lib/random_key'
+
+describe Keyable do
+  describe '#random_key' do
+    it 'returns a random 5 digit key' do
+      key = Keyable.random_key
+
+      expect(key).is_a? String
+      expect(key.length).to eq 5
+      expect(key.to_i).to be_between(0, 100_000).exclusive
+    end
+
+    # need to test that it zero-pads to the left (lpad)
+
+    # it 'returns expected 5 digit key' do
+    #   key = Keyable.random_key
+    #
+    #   expect(key.length).to eq 5
+    #   expect(key).to be_between(0, 100_000).exclusive
+    # end
+  end
+end

--- a/spec/keyable_spec.rb
+++ b/spec/keyable_spec.rb
@@ -17,4 +17,20 @@ describe Keyable do
       expect(key).to eq '00015'
     end
   end
+
+  describe '#date_today' do
+    it 'returns the date formatted as a string' do
+      key = Keyable.date_today
+
+      expect(key).is_a? String
+      expect(key.length).to eq 6
+    end
+
+    it 'properly formats a date' do
+      allow_any_instance_of(Date).to receive(:today) { Date.parse('2021-04-23') }
+      key = Keyable.date_today
+
+      expect(key).to eq '042321'
+    end
+  end
 end

--- a/spec/keyable_spec.rb
+++ b/spec/keyable_spec.rb
@@ -27,7 +27,7 @@ describe Keyable do
     end
 
     it 'properly formats a date' do
-      allow_any_instance_of(Date).to receive(:today) { Date.parse('2021-04-23') }
+      allow(Date).to receive(:today) { Date.parse('2021-04-23') }
       key = Keyable.date_today
 
       expect(key).to eq '042321'

--- a/spec/keyable_spec.rb
+++ b/spec/keyable_spec.rb
@@ -1,4 +1,4 @@
-require './lib/random_key'
+require './lib/keyable'
 
 describe Keyable do
   describe '#random_key' do
@@ -10,13 +10,11 @@ describe Keyable do
       expect(key.to_i).to be_between(0, 100_000).exclusive
     end
 
-    # need to test that it zero-pads to the left (lpad)
+    it 'l-pads 0s for numbers below 10000' do
+      allow_any_instance_of(Array).to receive(:sample) { 15 }
+      key = Keyable.random_key
 
-    # it 'returns expected 5 digit key' do
-    #   key = Keyable.random_key
-    #
-    #   expect(key.length).to eq 5
-    #   expect(key).to be_between(0, 100_000).exclusive
-    # end
+      expect(key).to eq '00015'
+    end
   end
 end


### PR DESCRIPTION
## Changes

Added functionality for Enigma to take only a message as input and to generate a key and/or date using the module Keyable when needed. This was tested using stubs to remove randomness from the testing for both Keyable and Enigma. 

## Checklist
- [x] Tests passing
- [x] Rubocop run
- [x] Full test coverage
- [x] Ready to merge

closes #8 
closes #9 