### PR TITLE
Create Enigma#crack method to decrypt without a key given

### DIFF
--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -24,7 +24,7 @@ class Enigma
   def crack(message, date = Keyable.date_today)
     codebreaker = ' end'
     shifts = shifts_from_codebreaker(message, codebreaker)
-    key = get_key(shifts, date)
+    key = find_key(shifts, date)
     decrypt(message, key, date)
   end
 
@@ -99,17 +99,13 @@ class Enigma
     base_shifts.rotate(shift_position)
   end
 
-  def get_key(shifts, date)
+  def find_key(shifts, date)
     offsets = shift_offsets(date)
-    # normalized_keys = shifts.map do |shift|
-    #   while shift < 0
-    #     shift += 27
-    #   end
-    #   while shift > 27
-    #     shift -= 27
-    #   end
-    #     shift
-    # end
+    keys = find_shift_keys(shifts, offsets)
+    keys[0] + keys[1][1] + keys[2][1] + keys[3][1]
+  end
+
+  def find_shift_keys(shifts, offsets)
     normalized_shifts = normalize(shifts)
     keys = []
     normalized_shifts.zip(offsets) do |pair|
@@ -159,7 +155,7 @@ class Enigma
       a[1] == b[0] && b[1] == c[0] && c[1] == key_d[0]
     end
     final_keys << d
-    final_keys[0] + final_keys[1][1] + final_keys[2][1] + final_keys[3][1]
+    final_keys
   end
 
   def normalize(shifts)

--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -33,24 +33,24 @@ class Enigma
     letter_indexes.map do |letter_index|
       n = find_n(index, shifts)
       index += 1
-      if letter_index.is_a? String
-        letter_index
-      else
-        (letter_index + n) % 27
-      end
+      shift_by_n(letter_index, n)
     end
   end
 
   def decrypt_by_index(letter_indexes, shifts)
     index = 0
     letter_indexes.map do |letter_index|
-      n = find_n(index, shifts)
+      n = find_n(index, shifts) * -1
       index += 1
-      if letter_index.is_a? String
-        letter_index
-      else
-        (letter_index - n) % 27
-      end
+      shift_by_n(letter_index, n)
+    end
+  end
+
+  def shift_by_n(index, n)
+    if index.is_a? String
+      index
+    else
+      (index + n) % 27
     end
   end
 
@@ -88,12 +88,12 @@ class Enigma
   end
 
   def shifts_from_codebreaker(message, codebreaker)
-    last_four = message[-4..].split('')
+    last_four = message[-4..].chars
     base_shifts = []
-    last_four.zip(codebreaker.split('')) do |pair|
+    last_four.zip(codebreaker.chars) do |pair|
       encrypted = letters.find_index(pair[0])
       decrypted = letters.find_index(pair[1])
-      base_shifts << encrypted- decrypted
+      base_shifts << encrypted - decrypted
     end
     shift_position = 4 - (message.length % 4)
     base_shifts.rotate(shift_position)
@@ -108,7 +108,7 @@ class Enigma
   def find_shift_keys(shifts, offsets)
     all_possible_keys = possible_keys_by_position(shifts, offsets)
     formatted_keys = all_possible_keys.map do |keys|
-      keys.map {|key| key.to_s.rjust(2, '0')}
+      keys.map { |key| key.to_s.rjust(2, '0') }
     end
     shift_keys = Hash.new('')
     formatted_keys[0].find do |key_a|
@@ -146,7 +146,7 @@ class Enigma
     normalized_shifts = normalize(shifts)
     keys = []
     normalized_shifts.zip(offsets) do |pair|
-      shift_key = pair[0] - pair [1]
+      shift_key = pair[0] - pair[1]
       keys << shift_key
     end
     keys
@@ -154,12 +154,8 @@ class Enigma
 
   def normalize(shifts)
     shifts.map do |shift|
-      while shift < 0
-        shift += 27
-      end
-      while shift > 27
-        shift -= 27
-      end
+      shift += 27 while shift.negative?
+      shift -= 27 while shift > 27
       shift
     end
   end

--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -22,21 +22,8 @@ class Enigma
   end
 
   def crack(message, date = Keyable.date_today)
-    # last_four = message[-4..].split('')
-    # base_shifts = []
-    # last_four.zip(' end'.split('')) do |pair|
-    #   encrypted = letters.find_index(pair[0])
-    #   decrypted = letters.find_index(pair[1])
-    #   base_shifts << encrypted - decrypted
-    # end
-    # shift_position = 4 - (message.length % 4)
-    # shifts = base_shifts.rotate(shift_position)
     codebreaker = ' end'
     shifts = shifts_from_codebreaker(message, codebreaker)
-
-    letter_indexes = convert_to_indexes(message)
-    decryption = decrypt_by_index(letter_indexes, shifts)
-
     key = get_key(shifts, date)
     decrypt(message, key, date)
   end
@@ -106,25 +93,26 @@ class Enigma
     last_four.zip(codebreaker.split('')) do |pair|
       encrypted = letters.find_index(pair[0])
       decrypted = letters.find_index(pair[1])
-      base_shifts << encrypted - decrypted
+      base_shifts << encrypted- decrypted
     end
     shift_position = 4 - (message.length % 4)
     base_shifts.rotate(shift_position)
-  end 
+  end
 
   def get_key(shifts, date)
     offsets = shift_offsets(date)
-    normalized_keys = shifts.map do |shift|
-      while shift < 0
-        shift += 27
-      end
-      while shift > 27
-        shift -= 27
-      end
-        shift
-    end
+    # normalized_keys = shifts.map do |shift|
+    #   while shift < 0
+    #     shift += 27
+    #   end
+    #   while shift > 27
+    #     shift -= 27
+    #   end
+    #     shift
+    # end
+    normalized_shifts = normalize(shifts)
     keys = []
-    normalized_keys.zip(offsets) do |pair|
+    normalized_shifts.zip(offsets) do |pair|
       shift_key = pair[0] - pair [1]
       keys << shift_key
     end
@@ -172,6 +160,18 @@ class Enigma
     end
     final_keys << d
     final_keys[0] + final_keys[1][1] + final_keys[2][1] + final_keys[3][1]
+  end
+
+  def normalize(shifts)
+    shifts.map do |shift|
+      while shift < 0
+        shift += 27
+      end
+      while shift > 27
+        shift -= 27
+      end
+      shift
+    end
   end
 
   def get_shifts(key, date)

--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -106,14 +106,17 @@ class Enigma
   end
 
   def find_shift_keys(shifts, offsets)
-    normalized_shifts = normalize(shifts)
-    keys = []
-    normalized_shifts.zip(offsets) do |pair|
-      shift_key = pair[0] - pair [1]
-      keys << shift_key
-    end
+    base_keys = key_baselines(shifts, offsets)
+    # normalized_shifts = normalize(shifts)
+    # keys = []
+    # normalized_shifts.zip(offsets) do |pair|
+    #   shift_key = pair[0] - pair [1]
+    #   keys << shift_key
+    # end
+
+    # all_possible_keys = possible_keys_by_position(base_keys)
     set = (0..100).to_a
-    possible_keys = keys.map do |key|
+    possible_keys = base_keys.map do |key|
       possibilities = set.find_all do |num|
         num % 27 == key
       end
@@ -157,6 +160,16 @@ class Enigma
     final_keys << d
     final_keys
   end
+
+  def key_baselines(shifts, offsets)
+    normalized_shifts = normalize(shifts)
+    keys = []
+    normalized_shifts.zip(offsets) do |pair|
+      shift_key = pair[0] - pair [1]
+      keys << shift_key
+    end
+    keys
+  end 
 
   def normalize(shifts)
     shifts.map do |shift|

--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -88,7 +88,7 @@ class Enigma
   end
 
   def shifts_from_codebreaker(message, codebreaker)
-    last_four = message[-4..].chars
+    last_four = message[-4..-1].chars
     base_shifts = []
     last_four.zip(codebreaker.chars) do |pair|
       encrypted = letters.find_index(pair[0])

--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -22,15 +22,17 @@ class Enigma
   end
 
   def crack(message, date = Keyable.date_today)
-    last_four = message[-4..].split('')
-    base_shifts = []
-    last_four.zip(' end'.split('')) do |pair|
-      encrypted = letters.find_index(pair[0])
-      decrypted = letters.find_index(pair[1])
-      base_shifts << encrypted - decrypted
-    end
-    shift_position = 4 - (message.length % 4)
-    shifts = base_shifts.rotate(shift_position)
+    # last_four = message[-4..].split('')
+    # base_shifts = []
+    # last_four.zip(' end'.split('')) do |pair|
+    #   encrypted = letters.find_index(pair[0])
+    #   decrypted = letters.find_index(pair[1])
+    #   base_shifts << encrypted - decrypted
+    # end
+    # shift_position = 4 - (message.length % 4)
+    # shifts = base_shifts.rotate(shift_position)
+    codebreaker = ' end'
+    shifts = shifts_from_codebreaker(message, codebreaker)
 
     letter_indexes = convert_to_indexes(message)
     decryption = decrypt_by_index(letter_indexes, shifts)
@@ -97,6 +99,18 @@ class Enigma
       shifts[3]
     end
   end
+
+  def shifts_from_codebreaker(message, codebreaker)
+    last_four = message[-4..].split('')
+    base_shifts = []
+    last_four.zip(codebreaker.split('')) do |pair|
+      encrypted = letters.find_index(pair[0])
+      decrypted = letters.find_index(pair[1])
+      base_shifts << encrypted - decrypted
+    end
+    shift_position = 4 - (message.length % 4)
+    base_shifts.rotate(shift_position)
+  end 
 
   def get_key(shifts, date)
     offsets = shift_offsets(date)

--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -102,63 +102,44 @@ class Enigma
   def find_key(shifts, date)
     offsets = shift_offsets(date)
     keys = find_shift_keys(shifts, offsets)
-    keys[0] + keys[1][1] + keys[2][1] + keys[3][1]
+    keys[:A] + keys[:B][1] + keys[:C][1] + keys[:D][1]
   end
 
   def find_shift_keys(shifts, offsets)
-    base_keys = key_baselines(shifts, offsets)
-    # normalized_shifts = normalize(shifts)
-    # keys = []
-    # normalized_shifts.zip(offsets) do |pair|
-    #   shift_key = pair[0] - pair [1]
-    #   keys << shift_key
-    # end
-
-    # all_possible_keys = possible_keys_by_position(base_keys)
-    set = (0..100).to_a
-    possible_keys = base_keys.map do |key|
-      possibilities = set.find_all do |num|
-        num % 27 == key
-      end
-      if possibilities.length.zero?
-        [27]
-      else
-        possibilities
-      end
+    all_possible_keys = possible_keys_by_position(shifts, offsets)
+    formatted_keys = all_possible_keys.map do |keys|
+      keys.map {|key| key.to_s.rjust(2, '0')}
     end
-    string_keys = possible_keys.map do |array|
-      array.map {|shift| shift.to_s.rjust(2, '0')}
-    end
-    final_keys = []
-    a = string_keys[0].find do |key_a|
-      string_keys[1].find do |key_b|
-        string_keys[2].find do |key_c|
-          string_keys[3].find do |key_d|
+    shift_keys = Hash.new('')
+    formatted_keys[0].find do |key_a|
+      shift_keys[:A] = key_a
+      formatted_keys[1].find do |key_b|
+        shift_keys[:B] = key_b
+        formatted_keys[2].find do |key_c|
+          shift_keys[:C] = key_c
+          formatted_keys[3].find do |key_d|
+            shift_keys[:D] = key_d
             key_a[1] == key_b[0] && key_b[1] == key_c[0] && key_c[1] == key_d[0]
           end
         end
       end
     end
-    final_keys << a
-    b = string_keys[1].find do |key_b|
-      string_keys[2].find do |key_c|
-        string_keys[3].find do |key_d|
-          a[1] == key_b[0] && key_b[1] == key_c[0] && key_c[1] == key_d[0]
-        end
+    shift_keys
+  end
+
+  def possible_keys_by_position(shifts, offsets)
+    base_keys = key_baselines(shifts, offsets)
+    set = (0..100).to_a
+    base_keys.map do |key|
+      possible_keys = set.find_all do |num|
+        num % 27 == key
+      end
+      if possible_keys.length.zero?
+        [27]
+      else
+        possible_keys
       end
     end
-    final_keys << b
-    c = string_keys[2].find do |key_c|
-      string_keys[3].find do |key_d|
-        a[1] == b[0] && b[1] == key_c[0] && key_c[1] == key_d[0]
-      end
-    end
-    final_keys << c
-    d = string_keys[3].find do |key_d|
-      a[1] == b[0] && b[1] == c[0] && c[1] == key_d[0]
-    end
-    final_keys << d
-    final_keys
   end
 
   def key_baselines(shifts, offsets)
@@ -169,7 +150,7 @@ class Enigma
       keys << shift_key
     end
     keys
-  end 
+  end
 
   def normalize(shifts)
     shifts.map do |shift|

--- a/spec/enigma_spec.rb
+++ b/spec/enigma_spec.rb
@@ -224,8 +224,29 @@ describe Enigma do
       shifts = [14, 5, 5, -19]
       offsets = [6, 3, 2, 4]
 
-      expected = ["08", "83", "30", "04"]
+      expected = {
+                  A: "08",
+                  B: "83",
+                  C: "30",
+                  D: "04"
+                  }
       expect(enigma.find_shift_keys(shifts, offsets)).to eq expected
+    end
+  end
+
+  describe '#possible_keys_by_position' do
+    it 'calculates all possible keys for each position' do
+      enigma = Enigma.new
+      shifts = [14, 5, 5, -19]
+      offsets = [6, 3, 2, 4]
+
+      expected = [
+                  [8, 35, 62, 89],
+                  [2, 29, 56, 83],
+                  [3, 30, 57, 84],
+                  [4, 31, 58, 85]
+                ]
+      expect(enigma.possible_keys_by_position(shifts, offsets)).to eq expected
     end
   end
 

--- a/spec/enigma_spec.rb
+++ b/spec/enigma_spec.rb
@@ -130,6 +130,16 @@ describe Enigma do
     end
   end
 
+  describe '#get_key' do
+    it 'calculates the key from the date and shifts' do
+      enigma = Enigma.new
+      shifts = [14, 5, 5, -19]
+      date = '291018'
+
+      expect(enigma.get_key(shifts, date)).to eq '08304'
+    end
+  end
+
   describe '#encrypt_by_index' do
     it 'returns an array of encrypted letter indexes' do
       enigma = Enigma.new

--- a/spec/enigma_spec.rb
+++ b/spec/enigma_spec.rb
@@ -200,13 +200,13 @@ describe Enigma do
     end
   end
 
-  describe '#get_key' do
+  describe '#find_key' do
     it 'calculates the key from the date and shifts' do
       enigma = Enigma.new
       shifts = [14, 5, 5, -19]
       date = '291018'
 
-      expect(enigma.get_key(shifts, date)).to eq '08304'
+      expect(enigma.find_key(shifts, date)).to eq '08304'
     end
 
     it 'works for any combination of shifts and date' do
@@ -214,7 +214,7 @@ describe Enigma do
       shifts = [3, 27, 73, 20]
       date = '040895'
 
-      expect(enigma.get_key(shifts, date)).to eq '02715'
+      expect(enigma.find_key(shifts, date)).to eq '02715'
     end
   end
 
@@ -224,6 +224,17 @@ describe Enigma do
       shifts = [14, 5, 5, -19]
 
       expect(enigma.normalize(shifts)).to eq [14, 5, 5, 8]
+    end
+  end
+
+  describe '#find_shift_keys' do
+    it 'finds shift keys using shifts and offsets' do
+      enigma = Enigma.new
+      shifts = [14, 5, 5, -19]
+      offsets = [6, 3, 2, 4]
+
+      expected = ["08", "83", "30", "04"]
+      expect(enigma.find_shift_keys(shifts, offsets)).to eq expected
     end
   end
 

--- a/spec/enigma_spec.rb
+++ b/spec/enigma_spec.rb
@@ -213,8 +213,9 @@ describe Enigma do
       message = 'vjqtbeaweqihssi'
       codebreaker = ' end'
 
+      actual = enigma.shifts_from_codebreaker(message, codebreaker)
       expected = [14, 5, 5, -19]
-      expect(enigma.shifts_from_codebreaker(message, codebreaker)).to eq expected
+      expect(actual).to eq expected
     end
   end
 

--- a/spec/enigma_spec.rb
+++ b/spec/enigma_spec.rb
@@ -218,15 +218,6 @@ describe Enigma do
     end
   end
 
-  describe '#normalize' do
-    it 'normalizes shifts to within range 0-27' do
-      enigma = Enigma.new
-      shifts = [14, 5, 5, -19]
-
-      expect(enigma.normalize(shifts)).to eq [14, 5, 5, 8]
-    end
-  end
-
   describe '#find_shift_keys' do
     it 'finds shift keys using shifts and offsets' do
       enigma = Enigma.new
@@ -235,6 +226,15 @@ describe Enigma do
 
       expected = ["08", "83", "30", "04"]
       expect(enigma.find_shift_keys(shifts, offsets)).to eq expected
+    end
+  end
+
+  describe '#normalize' do
+    it 'normalizes shifts to within range 0-27' do
+      enigma = Enigma.new
+      shifts = [14, 5, 5, -19]
+
+      expect(enigma.normalize(shifts)).to eq [14, 5, 5, 8]
     end
   end
 

--- a/spec/enigma_spec.rb
+++ b/spec/enigma_spec.rb
@@ -117,6 +117,19 @@ describe Enigma do
     end
   end
 
+  describe '#crack' do
+    it 'returns a decrypted message without a key' do
+      enigma = Enigma.new
+
+      expected = {
+        decryption: 'vjqtbeaweqihssi',
+        key: '08304',
+        date: '291018'
+      }
+      expect(enigma.crack('vjqtbeaweqihssi', '291018')).to eq expected
+    end
+  end
+
   describe '#encrypt_by_index' do
     it 'returns an array of encrypted letter indexes' do
       enigma = Enigma.new

--- a/spec/enigma_spec.rb
+++ b/spec/enigma_spec.rb
@@ -229,6 +229,17 @@ describe Enigma do
     end
   end
 
+  describe '#key_baselines' do
+    it 'calculates key baselines' do
+      enigma = Enigma.new
+      shifts = [14, 5, 5, -19]
+      offsets = [6, 3, 2, 4]
+
+      expected = [8, 2, 3, 4]
+      expect(enigma.key_baselines(shifts, offsets)).to eq expected
+    end
+  end
+
   describe '#normalize' do
     it 'normalizes shifts to within range 0-27' do
       enigma = Enigma.new

--- a/spec/enigma_spec.rb
+++ b/spec/enigma_spec.rb
@@ -218,6 +218,15 @@ describe Enigma do
     end
   end
 
+  describe '#normalize' do
+    it 'normalizes shifts to within range 0-27' do
+      enigma = Enigma.new
+      shifts = [14, 5, 5, -19]
+
+      expect(enigma.normalize(shifts)).to eq [14, 5, 5, 8]
+    end
+  end
+
   describe '#get_shifts' do
     it 'calculates the four shifts' do
       enigma = Enigma.new

--- a/spec/enigma_spec.rb
+++ b/spec/enigma_spec.rb
@@ -122,7 +122,7 @@ describe Enigma do
       enigma = Enigma.new
 
       expected = {
-        decryption: 'vjqtbeaweqihssi',
+        decryption: 'hello world end',
         key: '08304',
         date: '291018'
       }

--- a/spec/enigma_spec.rb
+++ b/spec/enigma_spec.rb
@@ -158,7 +158,7 @@ describe Enigma do
       index = 0
       n = 3
 
-      expect(enigma.shift_by_index(index, n)).to eq 3
+      expect(enigma.shift_by_n(index, n)).to eq 3
     end
 
     it 'returns the index if it is not a letter or space' do
@@ -166,7 +166,7 @@ describe Enigma do
       index = '!'
       n = 3
 
-      expect(enigma.shift_by_index(index, n)).to eq '!'
+      expect(enigma.shift_by_n(index, n)).to eq '!'
     end
   end
 

--- a/spec/enigma_spec.rb
+++ b/spec/enigma_spec.rb
@@ -130,16 +130,6 @@ describe Enigma do
     end
   end
 
-  describe '#get_key' do
-    it 'calculates the key from the date and shifts' do
-      enigma = Enigma.new
-      shifts = [14, 5, 5, -19]
-      date = '291018'
-
-      expect(enigma.get_key(shifts, date)).to eq '08304'
-    end
-  end
-
   describe '#encrypt_by_index' do
     it 'returns an array of encrypted letter indexes' do
       enigma = Enigma.new
@@ -196,6 +186,35 @@ describe Enigma do
       shifts = [3, 27, 73, 20]
 
       expect(enigma.find_n(index, shifts)).to eq 73
+    end
+  end
+
+  describe '#shifts_from_codebreaker' do
+    it 'calculates the four shifts' do
+      enigma = Enigma.new
+      message = 'vjqtbeaweqihssi'
+      codebreaker = ' end'
+
+      expected = [14, 5, 5, -19]
+      expect(enigma.shifts_from_codebreaker(message, codebreaker)).to eq expected
+    end
+  end
+
+  describe '#get_key' do
+    it 'calculates the key from the date and shifts' do
+      enigma = Enigma.new
+      shifts = [14, 5, 5, -19]
+      date = '291018'
+
+      expect(enigma.get_key(shifts, date)).to eq '08304'
+    end
+
+    it 'works for any combination of shifts and date' do
+      enigma = Enigma.new
+      shifts = [3, 27, 73, 20]
+      date = '040895'
+
+      expect(enigma.get_key(shifts, date)).to eq '02715'
     end
   end
 

--- a/spec/enigma_spec.rb
+++ b/spec/enigma_spec.rb
@@ -152,6 +152,24 @@ describe Enigma do
     end
   end
 
+  describe '#shift_by_n' do
+    it 'shifts an index by an n value over letters' do
+      enigma = Enigma.new
+      index = 0
+      n = 3
+
+      expect(enigma.shift_by_index(index, n)).to eq 3
+    end
+
+    it 'returns the index if it is not a letter or space' do
+      enigma = Enigma.new
+      index = '!'
+      n = 3
+
+      expect(enigma.shift_by_index(index, n)).to eq '!'
+    end
+  end
+
   describe '#convert_to_indexes' do
     it 'converts a string into an array of indexes' do
       enigma = Enigma.new
@@ -225,11 +243,11 @@ describe Enigma do
       offsets = [6, 3, 2, 4]
 
       expected = {
-                  A: "08",
-                  B: "83",
-                  C: "30",
-                  D: "04"
-                  }
+        A: '08',
+        B: '83',
+        C: '30',
+        D: '04'
+      }
       expect(enigma.find_shift_keys(shifts, offsets)).to eq expected
     end
   end
@@ -241,11 +259,11 @@ describe Enigma do
       offsets = [6, 3, 2, 4]
 
       expected = [
-                  [8, 35, 62, 89],
-                  [2, 29, 56, 83],
-                  [3, 30, 57, 84],
-                  [4, 31, 58, 85]
-                ]
+        [8, 35, 62, 89],
+        [2, 29, 56, 83],
+        [3, 30, 57, 84],
+        [4, 31, 58, 85]
+      ]
       expect(enigma.possible_keys_by_position(shifts, offsets)).to eq expected
     end
   end


### PR DESCRIPTION
## Changes

- Added functionality for Enigma to crack encrypted messages with just the message and date (no key provided). Requires that the message ends in the codebreaker. 
- Refactored methods in Enigma to reduce duplication of code

## Checklist
- [x] Tests passing
- [x] Rubocop run
- [x] Full test coverage
- [x] Ready to merge

## Loose Ends

** Need to deal with edge case where the message given to #crack does not end in the codebreaker sequence. **

closes #18 